### PR TITLE
update for android N

### DIFF
--- a/src/android/cordovanetworkmanager/cordovaNetworkManager.java
+++ b/src/android/cordovanetworkmanager/cordovaNetworkManager.java
@@ -64,7 +64,7 @@ public class cordovaNetworkManager extends CordovaPlugin {
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
-        this.wifiManager = (WifiManager) cordova.getActivity().getSystemService(Context.WIFI_SERVICE);
+        this.wifiManager = (WifiManager) cordova.getActivity().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
     }
 
     @Override


### PR DESCRIPTION
The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing  to .getApplicationContext()  [WifiManagerLeak]